### PR TITLE
Harden SSTable block reads against corrupt/malicious input

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -139,6 +139,7 @@ mod tests {
       vec![0u8; size],
       std::sync::Arc::new(crate::comparator::BytewiseComparator),
     )
+    .unwrap()
   }
 
   #[test]

--- a/src/db/version_set.rs
+++ b/src/db/version_set.rs
@@ -369,7 +369,7 @@ impl Builder {
     for (level, mut level_files) in by_level.into_iter().enumerate() {
       if level == 0 {
         // L0: newest-first (sort by file number descending).
-        level_files.sort_by(|a, b| b.0.cmp(&a.0));
+        level_files.sort_by_key(|b| std::cmp::Reverse(b.0));
       } else {
         // L1+: sort by smallest key.
         level_files.sort_by(|a, b| a.1.smallest.cmp(&b.1.smallest));

--- a/src/table/block.rs
+++ b/src/table/block.rs
@@ -37,23 +37,34 @@ pub(crate) struct Block {
 impl Block {
   /// Wrap raw block bytes (as returned by `read_block`, minus trailer).
   ///
-  /// Panics if `data` is too short to hold a valid restart count.
-  pub(crate) fn new(data: Vec<u8>, comparator: Arc<dyn Comparator>) -> Self {
-    assert!(data.len() >= 4, "block too short: {} bytes", data.len());
+  /// Returns `Error::Corruption` if `data` is too short to hold a valid restart
+  /// array, rather than panicking — the bytes may come from a corrupt SSTable.
+  pub(crate) fn new(data: Vec<u8>, comparator: Arc<dyn Comparator>) -> Result<Self, Error> {
+    if data.len() < 4 {
+      return Err(Error::Corruption(format!(
+        "block too short: {} bytes",
+        data.len()
+      )));
+    }
     let num_restarts = u32::from_le_bytes(data[data.len() - 4..].try_into().unwrap()) as usize;
-    let restarts_size = num_restarts * 4 + 4; // offsets + count field
-    assert!(
-      data.len() >= restarts_size,
-      "block data ({} bytes) too short for {num_restarts} restart points",
-      data.len()
-    );
+    // `num_restarts` comes straight off disk; guard the multiply against overflow.
+    let restarts_size = num_restarts
+      .checked_mul(4)
+      .and_then(|v| v.checked_add(4)) // offsets + count field
+      .ok_or_else(|| Error::Corruption("block restart count overflow".to_owned()))?;
+    if data.len() < restarts_size {
+      return Err(Error::Corruption(format!(
+        "block data ({} bytes) too short for {num_restarts} restart points",
+        data.len()
+      )));
+    }
     let restarts_offset = data.len() - restarts_size;
-    Block {
+    Ok(Block {
       data: Arc::new(data),
       restarts_offset,
       num_restarts,
       comparator,
-    }
+    })
   }
 
   /// Return the raw block data bytes (used by the block cache for charge accounting).
@@ -74,6 +85,7 @@ impl Block {
       value_start: 0,
       value_len: 0,
       comparator: Arc::clone(&self.comparator),
+      status: None,
     }
   }
 }
@@ -101,6 +113,22 @@ pub(crate) struct BlockIter {
   value_len: usize,
   /// Comparator for user-key ordering.
   comparator: Arc<dyn Comparator>,
+  /// Sticky corruption error: set the first time a malformed entry is decoded.
+  /// Once set, the iterator is invalidated and stays that way.
+  status: Option<Error>,
+}
+
+/// Read a varint starting at `pos`, refusing to read past `limit` (the start of
+/// the restart array).  Returns `(value, new_pos)` or `None` on truncation.
+fn read_varu64_at(data: &[u8], pos: usize, limit: usize) -> Option<(u64, usize)> {
+  if pos > limit {
+    return None;
+  }
+  let (value, n) = read_varu64(&data[pos..limit]);
+  if n == 0 {
+    return None; // malformed or truncated varint
+  }
+  Some((value, pos + n))
 }
 
 impl BlockIter {
@@ -112,42 +140,74 @@ impl BlockIter {
   /// Decode the entry at `self.current`, updating `key`, `value_start`, `value_len`.
   ///
   /// Assumes `self.key` already holds the full key from the previous entry
-  /// (or is empty at a restart point).
+  /// (or is empty at a restart point).  A corrupt entry (bad varint, or a
+  /// length that runs past the restart array) invalidates the iterator and
+  /// records a sticky `status`, rather than panicking on an out-of-bounds slice.
   fn decode_entry(&mut self) {
-    let data = &*self.data;
-    let mut pos = self.current;
+    if self.try_decode_entry().is_none() {
+      self.mark_corrupt();
+    }
+  }
 
-    let (shared, n) = read_varu64(&data[pos..]);
-    pos += n;
-    let (unshared, n) = read_varu64(&data[pos..]);
-    pos += n;
-    let (vlen, n) = read_varu64(&data[pos..]);
-    pos += n;
+  /// Fallible core of `decode_entry`; returns `None` on any malformed field.
+  fn try_decode_entry(&mut self) -> Option<()> {
+    let data = &*self.data;
+    let limit = self.restarts_offset;
+
+    let (shared, pos) = read_varu64_at(data, self.current, limit)?;
+    let (unshared, pos) = read_varu64_at(data, pos, limit)?;
+    let (vlen, pos) = read_varu64_at(data, pos, limit)?;
 
     let shared = shared as usize;
     let unshared = unshared as usize;
     let vlen = vlen as usize;
 
-    self.key.truncate(shared);
-    self.key.extend_from_slice(&data[pos..pos + unshared]);
-    pos += unshared;
+    // `shared` can only reference bytes already in the reconstructed key.
+    if shared > self.key.len() {
+      return None;
+    }
+    // The unshared key suffix and the value must both fit before the restarts.
+    let key_end = pos.checked_add(unshared)?;
+    let value_end = key_end.checked_add(vlen)?;
+    if value_end > limit {
+      return None;
+    }
 
-    self.value_start = pos;
+    self.key.truncate(shared);
+    self.key.extend_from_slice(&data[pos..key_end]);
+    self.value_start = key_end;
     self.value_len = vlen;
+    Some(())
   }
 
-  /// Return the key stored at restart point `index` without modifying `self`.
-  fn key_at_restart(&self, index: usize) -> Vec<u8> {
+  /// Invalidate the iterator and record a sticky corruption error.
+  fn mark_corrupt(&mut self) {
+    self.current = self.restarts_offset;
+    // Make `value_start + value_len` land exactly at the restart array so the
+    // forward-scan loops in `seek_to_last`/`prev` terminate immediately.
+    self.value_start = self.restarts_offset;
+    self.value_len = 0;
+    self.key.clear();
+    if self.status.is_none() {
+      self.status = Some(Error::Corruption("corrupt block entry".to_owned()));
+    }
+  }
+
+  /// Return the key stored at restart point `index`, or `None` if the entry
+  /// there is malformed.  Does not modify `self`.
+  fn key_at_restart(&self, index: usize) -> Option<Vec<u8>> {
     let data = &*self.data;
-    let mut pos = self.restart_point(index);
-    // At a restart point shared_len is always 0.
-    let (_shared, n) = read_varu64(&data[pos..]);
-    pos += n;
-    let (unshared, n) = read_varu64(&data[pos..]);
-    pos += n;
-    let (_vlen, n) = read_varu64(&data[pos..]);
-    pos += n;
-    data[pos..pos + unshared as usize].to_vec()
+    let limit = self.restarts_offset;
+    // At a restart point shared_len is always 0, so the unshared suffix is the
+    // full key.
+    let (_shared, pos) = read_varu64_at(data, self.restart_point(index), limit)?;
+    let (unshared, pos) = read_varu64_at(data, pos, limit)?;
+    let (_vlen, pos) = read_varu64_at(data, pos, limit)?;
+    let key_end = pos.checked_add(unshared as usize)?;
+    if key_end > limit {
+      return None;
+    }
+    Some(data[pos..key_end].to_vec())
   }
 }
 
@@ -192,7 +252,13 @@ impl InternalIterator for BlockIter {
     let mut hi = self.num_restarts; // exclusive
     while lo + 1 < hi {
       let mid = lo + (hi - lo) / 2;
-      let restart_key = self.key_at_restart(mid);
+      let restart_key = match self.key_at_restart(mid) {
+        Some(k) => k,
+        None => {
+          self.mark_corrupt();
+          return;
+        }
+      };
       match cmp_internal_keys(restart_key.as_slice(), target, &*self.comparator) {
         std::cmp::Ordering::Less | std::cmp::Ordering::Equal => lo = mid,
         std::cmp::Ordering::Greater => hi = mid,
@@ -267,7 +333,7 @@ impl InternalIterator for BlockIter {
   }
 
   fn status(&self) -> Option<&Error> {
-    None // BlockIter is pure memory; no I/O errors possible.
+    self.status.as_ref()
   }
 }
 
@@ -285,6 +351,7 @@ mod tests {
       bb.finish().to_vec(),
       Arc::new(crate::comparator::BytewiseComparator),
     )
+    .unwrap()
   }
 
   #[test]
@@ -293,7 +360,8 @@ mod tests {
     let block = Block::new(
       bb.finish().to_vec(),
       Arc::new(crate::comparator::BytewiseComparator),
-    );
+    )
+    .unwrap();
     assert!(!block.iter().valid());
   }
 
@@ -374,7 +442,8 @@ mod tests {
     let block = Block::new(
       bb.finish().to_vec(),
       Arc::new(crate::comparator::BytewiseComparator),
-    );
+    )
+    .unwrap();
     let mut it = block.iter();
     it.seek_to_last();
     assert!(!it.valid());
@@ -442,5 +511,113 @@ mod tests {
     }
     let expected: Vec<u8> = (b'a'..=b'i').rev().collect();
     assert_eq!(keys, expected);
+  }
+
+  // ── Corruption handling ───────────────────────────────────────────────────
+  //
+  // A corrupt data block must never panic on an out-of-bounds slice; the
+  // iterator should go invalid and expose a sticky `Corruption` status.
+
+  fn bytewise() -> Arc<dyn Comparator> {
+    Arc::new(crate::comparator::BytewiseComparator)
+  }
+
+  /// Raw bytes of a valid single-entry block `("k" -> "v")`, restart_interval 16.
+  ///
+  /// Layout: `[shared=0][unshared=1][vlen=1]['k']['v'] [restart u32 = 0][count u32 = 1]`.
+  /// So byte 0 = shared, 1 = unshared, 2 = vlen, 3 = key, 4 = value;
+  /// `restarts_offset` = 5.
+  fn single_entry_bytes() -> Vec<u8> {
+    let mut bb = BlockBuilder::new(16);
+    bb.add(b"k", b"v");
+    bb.finish().to_vec()
+  }
+
+  #[test]
+  fn block_new_rejects_too_short() {
+    // Fewer than 4 bytes cannot even hold the restart count.
+    assert!(matches!(
+      Block::new(vec![0u8; 3], bytewise()),
+      Err(Error::Corruption(_))
+    ));
+  }
+
+  #[test]
+  fn block_new_rejects_oversized_restart_count() {
+    // 8 bytes: a (bogus) restart offset followed by a restart count of
+    // 0xFFFF_FFFF, which would require far more data than is present.
+    let mut data = vec![0u8; 4];
+    data.extend_from_slice(&u32::MAX.to_le_bytes());
+    assert!(matches!(
+      Block::new(data, bytewise()),
+      Err(Error::Corruption(_))
+    ));
+  }
+
+  #[test]
+  fn corrupt_unshared_length_marks_invalid() {
+    let mut data = single_entry_bytes();
+    data[1] = 0x7f; // unshared = 127, runs past the 5-byte entry region
+    let block = Block::new(data, bytewise()).unwrap();
+    let mut it = block.iter();
+    it.seek_to_first();
+    assert!(!it.valid());
+    assert!(matches!(it.status(), Some(Error::Corruption(_))));
+  }
+
+  #[test]
+  fn corrupt_value_length_marks_invalid() {
+    let mut data = single_entry_bytes();
+    data[2] = 0x7f; // vlen = 127, runs past the end of the block
+    let block = Block::new(data, bytewise()).unwrap();
+    let mut it = block.iter();
+    it.seek_to_first();
+    assert!(!it.valid());
+    assert!(matches!(it.status(), Some(Error::Corruption(_))));
+  }
+
+  #[test]
+  fn corrupt_shared_length_marks_invalid() {
+    let mut data = single_entry_bytes();
+    data[0] = 0x05; // shared = 5 at a restart point (must be 0; exceeds key len)
+    let block = Block::new(data, bytewise()).unwrap();
+    let mut it = block.iter();
+    it.seek_to_first();
+    assert!(!it.valid());
+    assert!(matches!(it.status(), Some(Error::Corruption(_))));
+  }
+
+  #[test]
+  fn truncated_varint_marks_invalid() {
+    let mut data = single_entry_bytes();
+    // Fill the whole entry region with continuation bytes: the varint never
+    // terminates before the restart array.
+    for b in data.iter_mut().take(5) {
+      *b = 0x80;
+    }
+    let block = Block::new(data, bytewise()).unwrap();
+    let mut it = block.iter();
+    it.seek_to_first();
+    assert!(!it.valid());
+    assert!(matches!(it.status(), Some(Error::Corruption(_))));
+  }
+
+  #[test]
+  fn corrupt_restart_key_in_seek_marks_invalid() {
+    // restart_interval=1 makes every entry a restart point, so `seek`'s binary
+    // search calls `key_at_restart` on an interior entry.  Each entry is
+    // [shared=0][unshared=1][vlen=1][key][val] = 5 bytes; entry 1 starts at
+    // offset 5, its unshared-length byte is at offset 6.
+    let mut bb = BlockBuilder::new(1);
+    bb.add(b"a", b"1");
+    bb.add(b"b", b"2");
+    bb.add(b"c", b"3");
+    let mut data = bb.finish().to_vec();
+    data[6] = 0x7f; // corrupt entry 1's unshared length
+    let block = Block::new(data, bytewise()).unwrap();
+    let mut it = block.iter();
+    it.seek(b"b");
+    assert!(!it.valid());
+    assert!(matches!(it.status(), Some(Error::Corruption(_))));
   }
 }

--- a/src/table/block_builder.rs
+++ b/src/table/block_builder.rs
@@ -138,7 +138,8 @@ mod tests {
     let block = Block::new(
       data,
       std::sync::Arc::new(crate::comparator::BytewiseComparator),
-    );
+    )
+    .unwrap();
     let it = block.iter();
     assert!(!it.valid());
   }
@@ -149,7 +150,8 @@ mod tests {
     let block = Block::new(
       data,
       std::sync::Arc::new(crate::comparator::BytewiseComparator),
-    );
+    )
+    .unwrap();
     let mut it = block.iter();
     it.seek_to_first();
     assert!(it.valid());
@@ -167,7 +169,8 @@ mod tests {
     let block = Block::new(
       data,
       std::sync::Arc::new(crate::comparator::BytewiseComparator),
-    );
+    )
+    .unwrap();
     let mut it = block.iter();
     it.seek_to_first();
     for (expected_k, expected_v) in pairs {
@@ -190,7 +193,8 @@ mod tests {
     let block = Block::new(
       data.clone(),
       std::sync::Arc::new(crate::comparator::BytewiseComparator),
-    );
+    )
+    .unwrap();
     // Verify all 6 entries readable in order.
     let mut it = block.iter();
     it.seek_to_first();
@@ -215,7 +219,8 @@ mod tests {
     let block = Block::new(
       data,
       std::sync::Arc::new(crate::comparator::BytewiseComparator),
-    );
+    )
+    .unwrap();
     let mut it = block.iter();
     it.seek(b"c");
     assert!(it.valid());
@@ -234,7 +239,8 @@ mod tests {
     let block = Block::new(
       data,
       std::sync::Arc::new(crate::comparator::BytewiseComparator),
-    );
+    )
+    .unwrap();
     let mut it = block.iter();
     it.seek_to_first();
     assert_eq!(it.key(), b"new");

--- a/src/table/format.rs
+++ b/src/table/format.rs
@@ -44,6 +44,12 @@ pub(crate) const TABLE_MAGIC_NUMBER: u64 = 0xdb4775248b80fb57;
 /// Block trailer: 1-byte compression type + 4-byte masked CRC32c.
 pub(crate) const BLOCK_TRAILER_SIZE: usize = 5;
 
+/// Upper bound on a single block's size, both on disk (`BlockHandle::size`) and
+/// after decompression.  A corrupt handle or compressed-length header must not
+/// be able to trigger an unbounded allocation before any checksum is verified.
+/// Matches the ceiling already used for Zstd decompression.
+pub(crate) const MAX_BLOCK_SIZE: usize = 16 * 1024 * 1024;
+
 /// Maximum encoded size of a `BlockHandle` (two varint64s, up to 10 bytes each).
 const MAX_ENCODED_HANDLE_LENGTH: usize = 20;
 
@@ -202,6 +208,11 @@ pub(crate) fn read_block(
   verify_checksums: bool,
 ) -> Result<BlockContents, Error> {
   let n = handle.size as usize;
+  if n > MAX_BLOCK_SIZE {
+    return Err(Error::Corruption(format!(
+      "block size {n} exceeds maximum {MAX_BLOCK_SIZE}"
+    )));
+  }
   let mut buf = vec![0u8; n + BLOCK_TRAILER_SIZE];
   read_exact_at(file, &mut buf, handle.offset)?;
 
@@ -226,6 +237,11 @@ pub(crate) fn read_block(
       // Snappy
       let decompressed = snap::raw::decompress_len(&buf[..n])
         .map_err(|e| Error::Corruption(format!("snappy length decode: {e}")))?;
+      if decompressed > MAX_BLOCK_SIZE {
+        return Err(Error::Corruption(format!(
+          "snappy decompressed size {decompressed} exceeds maximum {MAX_BLOCK_SIZE}"
+        )));
+      }
       let mut out = vec![0u8; decompressed];
       snap::raw::Decoder::new()
         .decompress(&buf[..n], &mut out)
@@ -234,7 +250,7 @@ pub(crate) fn read_block(
     }
     0x02 => {
       // Zstd
-      let out = zstd::bulk::decompress(&buf[..n], 16 * 1024 * 1024)
+      let out = zstd::bulk::decompress(&buf[..n], MAX_BLOCK_SIZE)
         .map_err(|e| Error::Corruption(format!("zstd decompress: {e}")))?;
       Ok(BlockContents { data: out })
     }
@@ -428,5 +444,22 @@ mod tests {
     // Trailer byte should be 0x00 (NoCompression) because the data didn't compress well.
     let trailer_type = buf[buf.len() - BLOCK_TRAILER_SIZE];
     assert_eq!(trailer_type, 0x00, "expected fallback to NoCompression");
+  }
+
+  #[test]
+  fn read_block_rejects_oversized_handle() {
+    // A corrupt handle claiming a size beyond MAX_BLOCK_SIZE must be rejected
+    // before allocating a buffer — the file itself is tiny.
+    let mut tmp = tempfile::tempfile().unwrap();
+    std::io::Write::write_all(&mut tmp, &[0u8; 16]).unwrap();
+    let ra = crate::env::random_access_from_file(tmp);
+    let handle = BlockHandle {
+      offset: 0,
+      size: (MAX_BLOCK_SIZE + 1) as u64,
+    };
+    assert!(matches!(
+      read_block(ra.as_ref(), &handle, false),
+      Err(Error::Corruption(_))
+    ));
   }
 }

--- a/src/table/reader.rs
+++ b/src/table/reader.rs
@@ -86,7 +86,7 @@ impl Table {
 
     // Read the index block.
     let index_contents = read_block(file.as_ref(), &footer.index_handle, false)?;
-    let index_block = Block::new(index_contents.data, Arc::clone(&comparator));
+    let index_block = Block::new(index_contents.data, Arc::clone(&comparator))?;
 
     // Optionally read the filter block from the metaindex.
     let filter = filter_policy.and_then(|policy| {
@@ -129,7 +129,7 @@ impl Table {
 
     // Cache miss (or no cache): read from disk.
     let contents = read_block(self.file.as_ref(), handle, verify)?;
-    let block = Block::new(contents.data, Arc::clone(&self.comparator));
+    let block = Block::new(contents.data, Arc::clone(&self.comparator))?;
 
     // Insert into the cache unless the caller asked us not to (e.g. bulk scan).
     if fill_cache {
@@ -259,7 +259,7 @@ impl Table {
 
       // Read from disk.
       let contents = read_block(file.as_ref(), &handle, verify_checksums)?;
-      let block = Block::new(contents.data, Arc::clone(&comparator));
+      let block = Block::new(contents.data, Arc::clone(&comparator))?;
 
       if fill_cache {
         if let Some(cache) = &block_cache {
@@ -286,7 +286,7 @@ impl Table {
     while idx.valid() {
       let (handle, _) = BlockHandle::decode_from(idx.value())?;
       let contents = read_block(self.file.as_ref(), &handle, false)?;
-      let data_block = Block::new(contents.data, Arc::clone(&self.comparator));
+      let data_block = Block::new(contents.data, Arc::clone(&self.comparator))?;
       let mut it = data_block.iter();
       it.seek_to_first();
       while it.valid() {
@@ -320,7 +320,7 @@ fn read_filter_block(
   let meta_block = Block::new(
     meta_contents.data,
     Arc::new(crate::comparator::BytewiseComparator),
-  );
+  )?;
 
   // Seek the metaindex for the key "filter.<policy_name>".
   let filter_key = format!("filter.{}", policy.name());


### PR DESCRIPTION
Corrupt or truncated `SSTabl`e data blocks could panic the process on a normal get. The block decoder sliced with lengths read straight off disk and never bounds-checked them, and since `verify_checksums` defaults to off, no CRC caught the bad bytes first. This brings the block-read path in line with the corruption handling the WAL/MANIFEST decoders already do (return Corruption, don't panic).

Changes
- Bounds-check the block decoder (table/block.rs): decode_entry now validates every varint and length against the block limit and marks the iterator corrupt instead of indexing out of bounds. A sticky Error::Corruption surfaces via the existing InternalIterator::status() and propagates up through the iterator stack. seek's restart-key path is guarded too.
- Block::new returns Result instead of assert!, with overflow-safe restart-array sizing. All call sites updated (? on the five reader paths, .unwrap() in tests).
- Cap allocations (table/format.rs): new MAX_BLOCK_SIZE (16 MiB); read_block rejects an oversized BlockHandle::size before allocating, and the Snappy decompressed-length header is bounded the same way (matching the pre-existing zstd cap).