### PR TITLE
fix(durability): fsync protocol for SSTables et al

### DIFF
--- a/src/db/compaction.rs
+++ b/src/db/compaction.rs
@@ -709,6 +709,13 @@ pub(crate) fn do_compaction(
     )?;
   }
 
+  // Each output file was fsync'd by TableBuilder::finish; one directory sync
+  // persists all their directory entries before install_compaction records
+  // them in the MANIFEST and the inputs become deletable.
+  if !outputs.is_empty() {
+    opts.file_system.sync_dir(path)?;
+  }
+
   log::info!(
     "compaction L{}→L{} complete: {} output files ({} bytes)",
     spec.level,

--- a/src/db/version_set.rs
+++ b/src/db/version_set.rs
@@ -31,8 +31,17 @@ pub(crate) fn write_current_file(
   manifest_number: u64,
   fs: &dyn crate::env::FileSystem,
 ) -> Result<(), Error> {
+  // Atomic replacement: write a temp file, fsync it, then rename over CURRENT
+  // and fsync the directory.  Rewriting CURRENT in place would brick the
+  // database if a crash left it truncated.  See LevelDB's SetCurrentFile.
   let content = format!("{}\n", manifest_filename(manifest_number));
-  fs.write_string_to_file(&path.join("CURRENT"), &content)
+  let tmp_path = path.join(format!("{manifest_number:06}.dbtmp"));
+  fs.write_string_to_file(&tmp_path, &content)?;
+  if let Err(e) = fs.rename(&tmp_path, &path.join("CURRENT")) {
+    let _ = fs.remove_file(&tmp_path);
+    return Err(e);
+  }
+  fs.sync_dir(path)
 }
 
 fn read_current_file(path: &Path, fs: &dyn crate::env::FileSystem) -> Result<String, Error> {
@@ -95,6 +104,8 @@ impl VersionSet {
     edit.last_sequence = Some(0);
     edit.log_number = Some(1);
     manifest_log.add_record(&edit.encode())?;
+    // The MANIFEST must be durable before CURRENT points at it.
+    manifest_log.sync()?;
 
     write_current_file(path, manifest_number, fs)?;
 
@@ -196,6 +207,10 @@ impl VersionSet {
     edit.log_number = Some(self.log_number);
 
     self.manifest_log.add_record(&edit.encode())?;
+    // Sync before installing the new version in memory: once this returns,
+    // callers may delete files (old WALs, compacted SSTables) that are only
+    // recoverable while the pre-edit MANIFEST state is intact on disk.
+    self.manifest_log.sync()?;
 
     // Build new Version by cloning current and applying additions/deletions.
     let mut new_files: [Vec<Arc<FileMetaData>>; 7] =

--- a/src/env.rs
+++ b/src/env.rs
@@ -108,6 +108,13 @@ pub trait FileSystem: Send + Sync {
   /// Remove an empty directory.
   fn remove_dir(&self, path: &Path) -> Result<(), Error>;
 
+  /// Durably persist the directory entries of `path` (`fsync` on the directory).
+  ///
+  /// Required after creating or renaming a file for the new directory entry to
+  /// survive a crash — syncing the file itself only persists its contents.
+  /// Backends without directory metadata (e.g. in-memory) may no-op.
+  fn sync_dir(&self, path: &Path) -> Result<(), Error>;
+
   /// List the names of files and subdirectories in `path`.
   fn children(&self, path: &Path) -> Result<Vec<String>, Error>;
 
@@ -116,10 +123,13 @@ pub trait FileSystem: Send + Sync {
   /// Returns `Err` immediately if the lock is held by another process.
   fn lock_file(&self, path: &Path) -> Result<Box<dyn FileLock>, Error>;
 
-  /// Write `data` to `path` atomically (create or overwrite).
+  /// Write `data` to `path` durably (create or overwrite, then `fsync`).
   ///
-  /// Default implementation writes to the file directly.  Backends that
-  /// support atomic rename may write to a temporary file first.
+  /// Not atomic: a crash mid-write can leave a truncated file.  Callers that
+  /// need atomic replacement must write to a temporary file and [`rename`]
+  /// (see `write_current_file` in `db/version_set.rs`).
+  ///
+  /// [`rename`]: FileSystem::rename
   fn write_string_to_file(&self, path: &Path, data: &str) -> Result<(), Error> {
     let mut f = self.create_writable(path)?;
     f.write(data.as_bytes())?;
@@ -272,6 +282,12 @@ impl FileSystem for PosixFileSystem {
     std::fs::remove_dir(path).map_err(Error::IoError)
   }
 
+  fn sync_dir(&self, path: &Path) -> Result<(), Error> {
+    // Opening a directory read-only and fsync-ing it persists its entries.
+    let dir = std::fs::File::open(path).map_err(Error::IoError)?;
+    dir.sync_all().map_err(Error::IoError)
+  }
+
   fn children(&self, path: &Path) -> Result<Vec<String>, Error> {
     let entries = std::fs::read_dir(path).map_err(Error::IoError)?;
     let mut names = Vec::new();
@@ -300,10 +316,6 @@ impl FileSystem for PosixFileSystem {
       return Err(Error::IoError(std::io::Error::last_os_error()));
     }
     Ok(Box::new(PosixFileLock { _file: file }))
-  }
-
-  fn write_string_to_file(&self, path: &Path, data: &str) -> Result<(), Error> {
-    std::fs::write(path, data).map_err(Error::IoError)
   }
 
   fn read_string_from_file(&self, path: &Path) -> Result<String, Error> {
@@ -596,6 +608,11 @@ mod memfs {
       Ok(())
     }
 
+    fn sync_dir(&self, _path: &Path) -> Result<(), Error> {
+      // In-memory: directory entries are always "durable".
+      Ok(())
+    }
+
     fn children(&self, path: &Path) -> Result<Vec<String>, Error> {
       let st = self.state.lock().unwrap();
       if !st.dirs.contains(path) {
@@ -762,6 +779,16 @@ mod tests {
   }
 
   #[test]
+  fn posix_sync_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let fs = PosixFileSystem;
+    fs.create_writable(&dir.path().join("f.txt")).unwrap();
+    fs.sync_dir(dir.path()).unwrap();
+    // Syncing a non-existent directory must error, not panic.
+    assert!(fs.sync_dir(&dir.path().join("no_such_dir")).is_err());
+  }
+
+  #[test]
   fn posix_appendable() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("append.txt");
@@ -893,6 +920,13 @@ mod tests {
     fs.remove_file(dst).unwrap();
     assert!(!fs.file_exists(dst));
     assert!(matches!(fs.remove_file(dst), Err(Error::IoError(_))));
+  }
+
+  #[test]
+  fn mem_sync_dir_is_noop() {
+    let fs = MemFileSystem::new();
+    fs.create_dir_all(Path::new("/db")).unwrap();
+    fs.sync_dir(Path::new("/db")).unwrap();
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,7 +556,13 @@ impl Drop for Db {
     if self.inner.persistence.is_some() {
       log::info!("shutting down database");
       self.inner.shutting_down.store(true, Ordering::Release);
+      // Notify while holding the state mutex: bg_worker checks shutting_down
+      // under this mutex before parking on bg_condvar, so an unlocked notify
+      // can land between its check and its park and be lost — leaving the
+      // join below waiting forever.
+      let g = self.inner.state.lock().unwrap();
       self.inner.bg_condvar.notify_one();
+      drop(g);
       if let Some(t) = self.bg_thread.take() {
         t.join().ok();
       }
@@ -1655,6 +1661,8 @@ impl Db {
     let manifest_file = fs.create_writable(&manifest_path)?;
     let mut manifest_writer = LogWriter::new(manifest_file, 0);
     manifest_writer.add_record(&edit.encode())?;
+    // Durable before CURRENT points at it (and before old manifests go away).
+    manifest_writer.sync()?;
 
     // Delete old manifests.
     for name in &manifests {
@@ -1953,6 +1961,8 @@ fn write_flush_from_mem(
     }
   }
   let file_size = builder.finish()?;
+  // Persist the new SSTable's directory entry before it enters the MANIFEST.
+  fs.sync_dir(path)?;
   let read_file = fs.open_random_access(&sst_path)?;
   let table = Arc::new(Table::open(
     read_file,
@@ -2058,6 +2068,12 @@ fn write_flush(prep: FlushPrep, opts: &Options) -> Result<FlushResult, Error> {
     }
   }
   let file_size = builder.finish()?;
+  // Persist the directory entries for the new SSTable and the new WAL
+  // (created in begin_flush) before finish_flush records them in the MANIFEST
+  // and deletes the old WAL.
+  if let Some(dir) = sst_path.parent() {
+    fs.sync_dir(dir)?;
+  }
   drop(old_mem);
   let read_file = fs.open_random_access(&sst_path)?;
   let table = Arc::new(Table::open(
@@ -2447,6 +2463,10 @@ enum FileKind {
   Table,
   Current,
   Lock,
+  /// Temporary file from an interrupted atomic-rename (e.g. `CURRENT` update).
+  /// Always safe to delete: a live temp file only exists inside
+  /// `write_current_file`, which never runs concurrently with GC.
+  Temp,
 }
 
 /// Parse a database filename into `(file_number, kind)`.
@@ -2473,6 +2493,10 @@ fn parse_db_filename(name: &str) -> Option<(u64, FileKind)> {
   if let Some(stem) = name.strip_suffix(".ldb") {
     let n = stem.parse().ok()?;
     return Some((n, FileKind::Table));
+  }
+  if let Some(stem) = name.strip_suffix(".dbtmp") {
+    let n = stem.parse().ok()?;
+    return Some((n, FileKind::Temp));
   }
   None
 }
@@ -2527,6 +2551,7 @@ fn delete_obsolete_files(
         FileKind::Manifest => number >= manifest_number,
         FileKind::Table => live_tables.contains(&number),
         FileKind::Current | FileKind::Lock => true,
+        FileKind::Temp => false,
       };
       if !keep {
         log::debug!("deleting obsolete file: {name}");
@@ -2557,6 +2582,8 @@ mod tests {
       ("LOCK", 0, FileKind::Lock),
       ("MANIFEST-2", 2, FileKind::Manifest),
       ("MANIFEST-7", 7, FileKind::Manifest),
+      ("000005.dbtmp", 5, FileKind::Temp),
+      ("100.dbtmp", 100, FileKind::Temp),
       // u64::MAX
       (
         "18446744073709551615.log",
@@ -2596,6 +2623,8 @@ mod tests {
       "100",
       "100.",
       "100.lop",
+      ".dbtmp",
+      "x.dbtmp",
       // u64 overflow
       "18446744073709551616.log",
       "184467440737095516150.log",
@@ -3351,6 +3380,40 @@ mod tests {
       !orphan.exists(),
       "orphan .ldb file should have been deleted"
     );
+  }
+
+  #[test]
+  fn stale_dbtmp_file_deleted_by_gc() {
+    // A leftover *.dbtmp (crash between temp-write and rename in
+    // write_current_file) must be cleaned up by delete_obsolete_files.
+    let dir = tempfile::tempdir().unwrap();
+    {
+      let db = Db::open(dir.path(), small_options()).unwrap();
+      db.put(b"k", b"v").unwrap();
+    }
+    let stale = dir.path().join("000123.dbtmp");
+    std::fs::write(&stale, b"MANIFEST-000123\n").unwrap();
+
+    let db = Db::open(dir.path(), small_options()).unwrap();
+    for i in 0u32..20 {
+      db.put(format!("k{i:04}").as_bytes(), b"v2").unwrap();
+    }
+    db.flush(&crate::FlushOptions { wait: true }).unwrap();
+    assert!(!stale.exists(), "stale .dbtmp should have been deleted");
+  }
+
+  #[test]
+  fn current_written_via_rename_leaves_no_tmp() {
+    // write_current_file goes through a temp file + atomic rename; after any
+    // open no *.dbtmp may remain and CURRENT must point at a real MANIFEST.
+    let dir = tempfile::tempdir().unwrap();
+    {
+      let db = Db::open(dir.path(), small_options()).unwrap();
+      db.put(b"k", b"v").unwrap();
+    }
+    assert_eq!(count_files(dir.path(), ".dbtmp"), 0);
+    let current = std::fs::read_to_string(dir.path().join("CURRENT")).unwrap();
+    assert!(dir.path().join(current.trim()).exists());
   }
 
   #[test]

--- a/src/table/builder.rs
+++ b/src/table/builder.rs
@@ -210,6 +210,11 @@ impl TableBuilder {
     self.offset += FOOTER_ENCODED_LENGTH as u64;
 
     self.dest.flush()?;
+    // Durability before reference: every finished table is fsync'd before the
+    // caller can install it in the MANIFEST.  A crash must never leave the
+    // MANIFEST pointing at a torn SSTable.  See LevelDB's BuildTable and
+    // FinishCompactionOutputFile, which Sync() before LogAndApply.
+    self.dest.sync()?;
     Ok(self.offset)
   }
 


### PR DESCRIPTION
Bring the write-install ordering up to LevelDB's crash-safety contract (sync the file → sync the MANIFEST edit → install/delete), plus RocksDB's directory fsync. Previously none of these syncs happened:

- TableBuilder::finish now fsyncs the table file, so every SSTable (flush, open-time recovery, compaction output, repair) is durable before it can be referenced by the MANIFEST. A crash could previously leave the MANIFEST pointing at a torn .ldb after the WAL was already deleted.
- VersionSet::log_and_apply fsyncs the MANIFEST after each edit, before the new version is installed and old WALs/SSTs become deletable. Same in VersionSet::create and Db::repair, before CURRENT points at the new MANIFEST. An unsynced edit could previously lose sync=true writes.
- write_current_file now writes <manifest#>.dbtmp, fsyncs, renames over CURRENT, and fsyncs the directory (LevelDB's SetCurrentFile). It used to truncate CURRENT in place — and the PosixFileSystem write_string_td::fs::write with no sync at all (overri default nowapplies).
- New FileSystem fsync; Mem:no-op), called after flush (c rotated inbegin_flush), after compactiRENT rename, sodirectory entries survivents.
- New FileKind::Temp for *.dbtmp: GC deletes stragglers from a crash mid-rename; Db::destroy already handles them via parse_db_filenam